### PR TITLE
Add tool to compare against version number on GitHub

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -8,3 +8,4 @@ dependencies:
   - paramiko=2.6.0
   - astropy=3.2.1
   - sshtunnel
+  - requests

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -26,6 +26,8 @@ import subprocess
 import warnings
 import sshtunnel
 import platform
+import requests
+from packaging import version
 
 __version__ = '1.0.0rc2'
 
@@ -100,6 +102,7 @@ class KeckVncLauncher(object):
         ##---------------------------------------------------------------------
         self.log.debug("\n***** PROGRAM STARTED *****\nCommand: "+' '.join(sys.argv))
         self.log_system_info()
+        self.check_version()
 
         ##---------------------------------------------------------------------
         ## Authenticate Through Firewall (or Disconnect)
@@ -995,6 +998,7 @@ class KeckVncLauncher(object):
 #                  f"|  p               Play a local test sound",
                  f"  t               List local ports in use",
                  f"  c [port]        Close ssh tunnel on local port",
+                 f"  v               Check if software is up to date",
                  f"  q               Quit (or Control-C)",
                  f"-"*(line_length-2),
                  ]
@@ -1014,6 +1018,7 @@ class KeckVncLauncher(object):
             elif cmd == 'u': self.upload_log()
             elif cmd == 'l': self.print_sessions_found()
             elif cmd == 't': self.list_tunnels()
+            elif cmd == 'v': self.check_version()
             elif cmatch is not None: self.close_ssh_thread(int(cmatch.group(1)))
             #elif cmd == 'v': self.validate_ssh_key()
             #elif cmd == 'x': self.kill_vnc_processes()
@@ -1021,6 +1026,30 @@ class KeckVncLauncher(object):
                 self.start_vnc_session(cmd)
             else:
                 self.log.error(f'Unrecognized command: {cmd}')
+
+
+    ##-------------------------------------------------------------------------
+    ## Check for latest version number on GitHub
+    ##-------------------------------------------------------------------------
+    def check_version(self):
+        url = ('https://raw.githubusercontent.com/KeckObservatory/'
+               'RemoteObserving/master/keck_vnc_launcher.py')
+        r = requests.get(url)
+        findversion = re.search("__version__ = '(\d.+)'\n", r.text)
+        if findversion is not None:
+            remote_version = version.parse(findversion.group(1))
+            local_version = version.parse(__version__)
+        else:
+            self.log.warning(f'Unable to determine software version on GitHub')
+            return
+        if remote_version == local_version:
+            self.log.info(f'Your software is up to date (v{__version__})')
+        elif remote_version > local_version:
+            self.log.info(f'Your software (v{__version__}) is ahead of the released version')
+        else:
+            self.log.warning(f'Your local software (v{__version__}) is behind '
+                             f'the currently available version '
+                             f'(v{remote_version})')
 
 
     ##-------------------------------------------------------------------------

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -26,8 +26,6 @@ import subprocess
 import warnings
 import sshtunnel
 import platform
-import requests
-from packaging import version
 
 __version__ = '1.0.0rc2'
 
@@ -1034,23 +1032,27 @@ class KeckVncLauncher(object):
     def check_version(self):
         url = ('https://raw.githubusercontent.com/KeckObservatory/'
                'RemoteObserving/master/keck_vnc_launcher.py')
-        r = requests.get(url)
-        findversion = re.search("__version__ = '(\d.+)'\n", r.text)
-        if findversion is not None:
-            remote_version = version.parse(findversion.group(1))
-            local_version = version.parse(__version__)
-        else:
-            self.log.warning(f'Unable to determine software version on GitHub')
-            return
-        if remote_version == local_version:
-            self.log.info(f'Your software is up to date (v{__version__})')
-        elif remote_version > local_version:
-            self.log.info(f'Your software (v{__version__}) is ahead of the released version')
-        else:
-            self.log.warning(f'Your local software (v{__version__}) is behind '
-                             f'the currently available version '
-                             f'(v{remote_version})')
-
+        try:
+            import requests
+            from packaging import version
+            r = requests.get(url)
+            findversion = re.search("__version__ = '(\d.+)'\n", r.text)
+            if findversion is not None:
+                remote_version = version.parse(findversion.group(1))
+                local_version = version.parse(__version__)
+            else:
+                self.log.warning(f'Unable to determine software version on GitHub')
+                return
+            if remote_version == local_version:
+                self.log.info(f'Your software is up to date (v{__version__})')
+            elif remote_version > local_version:
+                self.log.info(f'Your software (v{__version__}) is ahead of the released version')
+            else:
+                self.log.warning(f'Your local software (v{__version__}) is behind '
+                                 f'the currently available version '
+                                 f'(v{remote_version})')
+        except:
+            log.warning("Unable to verify remote version")
 
     ##-------------------------------------------------------------------------
     ## Upload log file to Keck


### PR DESCRIPTION
Added a tool to check the version of the software that is in use and compare that against the version in the tip of the master branch on GitHub.  There may be a cleaner way to do this ...

Also, this adds `requests` as a requirement, so it requires a reinstall of the `KRO` conda environment if it has been previously installed.
