### PR TITLE
Move servers_to_try from config to program

### DIFF
--- a/keck_vnc_config.yaml
+++ b/keck_vnc_config.yaml
@@ -11,10 +11,6 @@
   ## and provided the public key to Keck, enter the full path the private key here.
   # ssh_pkey: '/home/observer/.ssh/id_rsa',
 
-  ## When first connecting to Keck to determine which VNC server to connect to
-  ## (i.e. where to run `kvncinfo -server`) this is the list of computers to try
-  servers_to_try: ['svncserver2', 'svncserver1', 'kcwi', 'mosfire'],
-
   ## This is the command to invoke on the local machine to launch a VNC client
   ## Command will be formatted as [vncviewer] [vncargs] [address]:[port]
   ## Example: Default setup for TigerVnC's vncviewer wither preferred arg options

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -69,6 +69,9 @@ class KeckVncLauncher(object):
             'telstatus',
         ]
 
+        #default servers to try at Keck
+        self.servers_to_try = ['svncserver2', 'svncserver1', 'kcwi', 'mosfire']
+
         #NOTE: 'status' session on different server and always on port 1, 
         # so assign localport to constant to avoid conflict
         self.STATUS_PORT       = ':1'
@@ -357,12 +360,6 @@ class KeckVncLauncher(object):
     ## Check Configuration
     ##-------------------------------------------------------------------------
     def check_config(self):
-
-        #checks servers_to try
-        self.servers_to_try = self.config.get('servers_to_try', None)
-        if not self.servers_to_try:
-            self.log.error("Config parameter 'servers_to_try' undefined.\n")
-            self.exit_app()
 
         #check for vncviewer
         #NOTE: Ok if not specified, we will tell them to open vncviewer manually


### PR DESCRIPTION
The servers_to_try config option was put in there by me as the code needs somewhere to connect to ask for the correct VNC server for the instrument requested.  Having a list made it more robust to a single machine going down.

In retrospect, this is not something the user should be configuring and it is something we should update in the software itself instead.  As a result, I've pulled this out of the default config file and put the list in as a property of the `KeckVncLauncher` object on `__init__`.

This should be harmless as the lines in old config files will simply be ignored.