### PR TITLE
Leave firewall open

### DIFF
--- a/keck_vnc_config.yaml
+++ b/keck_vnc_config.yaml
@@ -8,7 +8,8 @@
 
 ## If the firewall authentication has been performed, should the script
 ## de-authenticate when it exits? This is generally not required; the firewall
-## authorization will automatically expire after 24 hours.
+## authorization will automatically expire after 24 hours. Set this option to
+## True to close the firewall hole when the script exits.
 firewall_cleanup: False
 
 ## SSH private key file path.  If you created an ssh public/private key pair

--- a/keck_vnc_config.yaml
+++ b/keck_vnc_config.yaml
@@ -6,9 +6,14 @@
 # firewall_port: 123
 # firewall_user: '???'
 
+## If the firewall authentication has been performed, should the script
+## de-authenticate when it exits? This is generally not required; the firewall
+## authorization will automatically expire after 24 hours.
+firewall_cleanup: False
 
 ## SSH private key file path.  If you created an ssh public/private key pair
-## and provided the public key to Keck, enter the full path the private key here.
+## and provided the public key to Keck, enter the full path for the private key
+## here.
 # ssh_pkey: '/home/observer/.ssh/id_rsa'
 
 

--- a/keck_vnc_config.yaml
+++ b/keck_vnc_config.yaml
@@ -33,11 +33,11 @@ vncargs: '-Shared -FullColor -PreferredEncoding=ZRLE -AutoSelect=0'
 # vncargs: '-passwd=/home/observer/.vnc/passwd'
 
 
-## Default start sessions if none specified. 
+## Default start sessions if none specified.
 default_sessions: ['control0', 'control1', 'control2', 'telstatus']
 
 
-## For ssh tunnelling, a starting local port number is used and incremented 
+## For ssh tunnelling, a starting local port number is used and incremented
 ## for each port needed.  Default is 5901.
 # local_port_start: 50001
 

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -787,9 +787,9 @@ class KeckVncLauncher(object):
 
             # Ping once, wait up to five seconds for a response.
             if os == 'linux':
-                command.extend(['-c', '1,' '-w', '5']
+                command.extend(['-c', '1', '-w', '5'])
             elif os == 'darwin':
-                command.extend(['-c', '1,' '-W', '5000']
+                command.extend(['-c', '1', '-W', '5000'])
             else:
                 # Don't understand how ping works on this platform.
                 return False
@@ -799,6 +799,7 @@ class KeckVncLauncher(object):
             # authentication will be required.
             return False
 
+        self.log.debug('firewall test: ' + ' '.join (command))
         null = subprocess.DEVNULL
         proc = subprocess.Popen(command, stdin=null, stdout=null, stderr=null)
         result = proc.wait()

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -136,7 +136,7 @@ class KeckVncLauncher(object):
 
         if need_password == True:
             while self.firewall_pass is None:
-                firewall_pass = getpass.getpass(f"Password for firewall authentication: ")
+                firewall_pass = getpass(f"Password for firewall authentication: ")
                 firewall_pass = firewall_pass.strip()
                 if firewall_pass != '':
                     self.firewall_pass = firewall_pass
@@ -732,7 +732,7 @@ class KeckVncLauncher(object):
             return
 
         self.log.info('Closing firewall hole')
-        tn = telnetlib.Telnet(self.firewall_address, int(self.firewall_port))
+        tn = Telnet(self.firewall_address, int(self.firewall_port))
         tn.read_until(b"User: ", timeout=5)
         tn.write(f'{self.firewall_user}\n'.encode('ascii'))
         tn.read_until(b"password: ", timeout=5)

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -757,12 +757,12 @@ class KeckVncLauncher(object):
 
         try:
             netcat = subprocess.check_output(['which', 'ncat'])
-        except CalledProcessError:
+        except subprocess.CalledProcessError:
             netcat = None
 
         try:
             ping = subprocess.check_output(['which', 'ping'])
-        except CalledProcessError:
+        except subprocess.CalledProcessError:
             ping = None
 
 
@@ -775,12 +775,24 @@ class KeckVncLauncher(object):
         if netcat is not None:
             netcat = netcat.decode()
             netcat = netcat.strip()
-            command = [netcat, 'sshserver1.keck.hawaii.edu', '22', '-w 2']
+            command = [netcat, 'sshserver1.keck.hawaii.edu', '22', '-w', '2']
 
         elif ping is not None:
             ping = ping.decode()
             ping = ping.strip()
-            command = [ping, '128.171.95.100', '-c 1 -w 5']
+            command = [ping, '128.171.95.100']
+
+            os = platform.system()
+            os = os.lower()
+
+            # Ping once, wait up to five seconds for a response.
+            if os == 'linux':
+                command.extend(['-c', '1,' '-w', '5']
+            elif os == 'darwin':
+                command.extend(['-c', '1,' '-W', '5000']
+            else:
+                # Don't understand how ping works on this platform.
+                return False
 
         else:
             # No way to check the firewall status. Assume it is closed,


### PR DESCRIPTION
This branch addresses a couple things: one, it implements the firewall_cleanup option that was suggested in Slack. Two, it checks to see whether the firewall hole is already open, and doesn't prompt the user for the password if it's not required. Three, it requires the user to enter a non-empty firewall password when prompted.