### PR TITLE
ssh command line fixes

### DIFF
--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -554,7 +554,9 @@ class KeckVncLauncher(object):
         # not allocate a pseudo-terminal for the established connection.
 
         forwarding = f"{local_port}:localhost:{remote_port}"
-        command = ['ssh', '-l', username, '-L', forwarding, '-N', '-T', server]
+        command = ['ssh', server, '-l', username, '-L', forwarding, '-N', '-T']
+        command.append('-oStrictHostKeyChecking=no')
+        command.append('-oKexAlgorithms=+diffie-hellman-group1-sha1')
 
         if ssh_pkey is not None:
             command.append('-i')


### PR DESCRIPTION
Adjust the command line options to be more forgiving about connecting to ancient computers, and to automatically accept new host keys. Changed host keys will still throw warnings, but they're being piped to /dev/null.