### PR TITLE
Check for conda

### DIFF
--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -1,16 +1,22 @@
 #!/bin/bash
 
-#activate conda environment
-# NOTE: The KRO environment is created with: conda env create -f environment.yaml
-CONDA_BASE=$(conda info --base)
-source $CONDA_BASE/etc/profile.d/conda.sh
-conda activate KRO
-#NOTE: old method using 'source' will work too but not preferred
-#source activate KRO
+# If we're using conda python
+if [ -n `which conda` ]; then
+    #activate conda environment
+    # NOTE: The KRO environment is created with: conda env create -f environment.yaml
+    CONDA_BASE=$(conda info --base)
+    source $CONDA_BASE/etc/profile.d/conda.sh
+    conda activate KRO
+    #NOTE: old method using 'source' will work too but not preferred
+    source activate KRO
 
-#change to script dir (so we don't need full path to keck_vnc_launcher.py)
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR
+    #change to script dir (so we don't need full path to keck_vnc_launcher.py)
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    cd $DIR
 
-#launch
-python3 keck_vnc_launcher.py $@
+    #launch
+    $CONDA_BASE/envs/KRO/bin/python3 keck_vnc_launcher.py $@
+else
+    # just try whatever is in the path and hope it works
+    python3 keck_vnc_launcher.py $@
+fi

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -2,8 +2,9 @@
 
 # If we're using conda python
 if [ -n `which conda` ]; then
-    #activate conda environment
-    # NOTE: The KRO environment is created with: conda env create -f environment.yaml
+    # activate conda environment
+    # NOTE: The KRO environment is created with:
+    #       conda env create -f environment.yaml
     CONDA_BASE=$(conda info --base)
     source $CONDA_BASE/etc/profile.d/conda.sh
     conda activate KRO
@@ -12,8 +13,14 @@ if [ -n `which conda` ]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
     cd $DIR
 
-    #launch
-    $CONDA_BASE/envs/KRO/bin/python3 keck_vnc_launcher.py $@
+    # Launch the script
+    if [ -e $CONDA_BASE/envs/KRO/bin/python3 ]; then
+        # Launch using conda KRO environment
+        $CONDA_BASE/envs/KRO/bin/python3 keck_vnc_launcher.py $@
+    else
+        # Try launching via conda base environment
+        CONDA_BASE/bin/python3 keck_vnc_launcher.py $@
+    fi
 else
     # just try whatever is in the path and hope it works
     python3 keck_vnc_launcher.py $@

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -7,8 +7,6 @@ if [ -n `which conda` ]; then
     CONDA_BASE=$(conda info --base)
     source $CONDA_BASE/etc/profile.d/conda.sh
     conda activate KRO
-    #NOTE: old method using 'source' will work too but not preferred
-    # source activate KRO
 
     #change to script dir (so we don't need full path to keck_vnc_launcher.py)
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # If we're using conda python
-if [ "$CONDA" != "" ]; then
+if [ "$CONDA_PREFIX" != "" ]; then
     # activate conda environment
     # NOTE: The KRO environment is created with:
     #       conda env create -f environment.yaml

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -8,7 +8,7 @@ if [ -n `which conda` ]; then
     source $CONDA_BASE/etc/profile.d/conda.sh
     conda activate KRO
     #NOTE: old method using 'source' will work too but not preferred
-    source activate KRO
+    # source activate KRO
 
     #change to script dir (so we don't need full path to keck_vnc_launcher.py)
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # If we're using conda python
-if [ -n `which conda` ]; then
+if [ "$CONDA" != "" ]; then
     # activate conda environment
     # NOTE: The KRO environment is created with:
     #       conda env create -f environment.yaml

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -5,8 +5,7 @@ if [ -n `which conda` ]; then
     # activate conda environment
     # NOTE: The KRO environment is created with:
     #       conda env create -f environment.yaml
-    CONDA_BASE=$(conda info --base)
-    source $CONDA_BASE/etc/profile.d/conda.sh
+    source $CONDA_PREFIX/etc/profile.d/conda.sh
     conda activate KRO
 
     #change to script dir (so we don't need full path to keck_vnc_launcher.py)
@@ -14,12 +13,12 @@ if [ -n `which conda` ]; then
     cd $DIR
 
     # Launch the script
-    if [ -e $CONDA_BASE/envs/KRO/bin/python3 ]; then
+    if [ -e $CONDA_PREFIX/envs/KRO/bin/python3 ]; then
         # Launch using conda KRO environment
-        $CONDA_BASE/envs/KRO/bin/python3 keck_vnc_launcher.py $@
+        $CONDA_PREFIX/envs/KRO/bin/python3 keck_vnc_launcher.py $@
     else
         # Try launching via conda base environment
-        $CONDA_BASE/bin/python3 keck_vnc_launcher.py $@
+        $CONDA_PREFIX/bin/python3 keck_vnc_launcher.py $@
     fi
 else
     # just try whatever is in the path and hope it works

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -19,7 +19,7 @@ if [ -n `which conda` ]; then
         $CONDA_BASE/envs/KRO/bin/python3 keck_vnc_launcher.py $@
     else
         # Try launching via conda base environment
-        CONDA_BASE/bin/python3 keck_vnc_launcher.py $@
+        $CONDA_BASE/bin/python3 keck_vnc_launcher.py $@
     fi
 else
     # just try whatever is in the path and hope it works


### PR DESCRIPTION
Edits to the `start_keck_viewers` script to force the use of conda if it is available.  Should failover to whatever python is in the path if conda is unavailable.  This solves a problem related to path specs being modified by multiple installers.  In the particular example that triggered this, a brew update placed the brew installed python earlier in the path than anaconda even after the `conda activate` step was run.