### PR TITLE
Add pytest

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -6,3 +6,4 @@ dependencies:
   - yaml
   - pyyaml=5.1.2
   - requests
+  - pytest

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -1458,7 +1458,14 @@ def create_parser():
         help="Path to local configuration file.")
 
     #parse
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    ## If authonly is set, also set nosound because if the user doesn't want
+    ## VNCs, they likely don't want sound as well.
+    if args.authonly is True:
+        args.nosound = True
+
+    return args
 
 ##-------------------------------------------------------------------------
 ## Create logger


### PR DESCRIPTION
pytest appears to have been left off by accident.  Added it back in.  Only affects testing (obviously), but was a gotcha when setting up a new observer.