### PR TITLE
Fixed incorrect exit procedure when firewall password is entered incorrectly

### DIFF
--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -828,8 +828,6 @@ class KeckVncLauncher(object):
     ## Open and Close the firewall
     ##-------------------------------------------------------------------------
     def test_firewall(self):
-#todo: remove this test
-        return False
         ''' Return True if the sshuser firewall hole is open; otherwise
         return False. Also return False if the test cannot be performed.
         '''

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -828,6 +828,8 @@ class KeckVncLauncher(object):
     ## Open and Close the firewall
     ##-------------------------------------------------------------------------
     def test_firewall(self):
+#todo: remove this test
+        return False
         ''' Return True if the sshuser firewall hole is open; otherwise
         return False. Also return False if the test cannot be performed.
         '''
@@ -874,18 +876,15 @@ class KeckVncLauncher(object):
     def open_firewall(self, authpass):
         '''Simple wrapper to open firewall.
         '''
-        if do_firewall_command(self.firewall_address, self.firewall_port,
-                              self.firewall_user, authpass, 1):
-            return True
-        else:
-            self.exit_app()
+        return do_firewall_command(self.firewall_address, self.firewall_port,
+                                   self.firewall_user, authpass, 1)
 
 
     def close_firewall(self, authpass):
         '''Simple wrapper to close firewall.
         '''
-        do_firewall_command(self.firewall_address, self.firewall_port,
-                            self.firewall_user, authpass, 2)
+        return do_firewall_command(self.firewall_address, self.firewall_port,
+                                   self.firewall_user, authpass, 2)
 
 
     ##-------------------------------------------------------------------------
@@ -1948,6 +1947,7 @@ class KeckVncLauncher(object):
             if self.firewall_opened is False:
                 self.log.error('Failed to open firewall')
                 failcount += 1
+                self.exit_app('Authentication failure! Must be able to authenticate to finish tests.')
 
         return failcount
 


### PR DESCRIPTION
I'm not sure exactly why it wasn't exiting correctly, but the exit_app in open_firewall was unnecessary since the app exits on line 478 when open_firewall returns False, and my hunch to remove it seems to fix the problem.  I noticed the test_firewall_authentication function relied on that exit_app call so I changed it to also handle the exit itself, too.