### PR TITLE
Version 3.0.0: API and firewall transition

### DIFF
--- a/keck_vnc_config.yaml
+++ b/keck_vnc_config.yaml
@@ -5,7 +5,6 @@
 ##   Observer Homepage at https://www2.keck.hawaii.edu/inst/PILogin/homepage.php
 ##   Click on 'Manage your Remote Observing SSH key', follow the instructions
 ##   and paste your API key here when you have uploaded your SSH key. 
-##   If this is being run inside of the Keck network, comment out this line.
 api_key: ''
 
 

--- a/keck_vnc_config.yaml
+++ b/keck_vnc_config.yaml
@@ -96,14 +96,6 @@ default_sessions: ['control0', 'control1', 'control2', 'telstatus']
 #window_positions: [[0, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 3]]
 
 
-## Firewall Cleanup
-##   If the firewall authentication has been performed, should the script
-##   de-authenticate when it exits? This is generally not required; the
-##   firewall authorization will automatically expire after 24 hours. Set this
-##   option to True to close the firewall hole when the script exits.
-firewall_cleanup: False
-
-
 ## Firewall check
 ##   This is done using ping by default.  However, the netcat test is more
 ##   rigorous, in that it attempts to contact an ssh daemon that should be
@@ -121,15 +113,3 @@ firewall_cleanup: False
 ##   Sometimes extending the SSH timeout can eliminate failures for slow
 ##   machines or during internet slow downs.
 #ssh_timeout: 30
-
-
-## Firewall Connection Info:
-##   If you are not using the "api_key" defined above and are outside of the Keck 
-##   network and need to authenticate through the Keck firewall, fill out the 
-##   appropriate IP address, port, and username which will be used to authenticate. 
-##   If this is being run inside of the Keck network, comment out these lines.
-#firewall_address: ???.???.???.???
-#firewall_port: ???
-#firewall_user: ???
-
-

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -1432,7 +1432,7 @@ class KeckVncLauncher(object):
             self.log.warning(f'Port 8080 is in use, not starting proxy connection')
             return
         self.log.info(f'Opening SSH for proxy to port 8080')
-        t = SSHProxy(self.args.account,
+        t = SSHProxy(self.api_data.get('vncserver'),
                      self.kvnc_account, self.ssh_pkey,
                      local_port,
                      session_name='proxy',

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -1074,10 +1074,6 @@ class KeckVncLauncher(object):
         if vncserver:
             self.log.info(f"Got VNC server: '{vncserver}'")
 
-        # Temporary hack for KCWI
-        if vncserver == 'vm-kcwivnc':
-            vncserver = 'kcwi'
-
         if vncserver is not None and 'keck.hawaii.edu' not in vncserver:
             vncserver += '.keck.hawaii.edu'
 

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -4,7 +4,7 @@
 import os
 import argparse
 import atexit
-from datetime import datetime
+from datetime import datetime, timedelta
 from getpass import getpass
 import json
 import logging
@@ -887,10 +887,14 @@ class KeckVncLauncher(object):
         self.log.debug(f'Using URL: {KRO_API} with {params}')
         data = None
         try:
+            tick = datetime.now()
             data = requests.post(KRO_API, data=params, timeout=60)
             data = json.loads(data.text)
             for key in data.keys():
-                self.log.debug(f"  Got data for {key}")
+                self.log.debug(f"  Got data for {key}: {data[key]}")
+            tock = datetime.now()
+            duration = (tock-tick).total_seconds()
+            self.log.debug(f'API call took {duration:.1f} s')
         except Exception as e:
             self.log.error(f'Could not get data from API.')
             self.log.error(str(e))

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -814,6 +814,12 @@ class KeckVncLauncher(object):
                   'account': f"{account}"}
         self.log.info(f'Calling KRO API to get account info')
         self.log.debug(f'Using URL: {KRO_API} with {params}')
+        print()
+        print("-------------------------------------------------------------")
+        print("Please note: the initial connection to the Keck KRO API may")
+        print("take up to 1 minute to complete.")
+        print("-------------------------------------------------------------")
+        print()
         data = None
         try:
             tick = datetime.now()

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -811,7 +811,9 @@ class KeckVncLauncher(object):
         #form API url and get data
         params = {'key': f'{self.api_key}',
                   'account': f"{account}"}
-        self.log.info(f'Calling KRO API to get account info')
+        tick = datetime.now()
+        tick_str = tick.strftime("%H:%M:%S")
+        self.log.info(f'Calling KRO API at {tick_str} to get account info')
         self.log.debug(f'Using URL: {KRO_API} with {params}')
         print()
         print("-------------------------------------------------------------")
@@ -821,7 +823,6 @@ class KeckVncLauncher(object):
         print()
         data = None
         try:
-            tick = datetime.now()
             data = requests.post(KRO_API, data=params, timeout=90)
             data = json.loads(data.text)
             for key in data.keys():

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -108,10 +108,19 @@ def create_parser():
 
     ## Change default behavior if no account is given.
     if args.account == '':
-        ## Assume authonly if the vncserver and vncports are not specified
-        if args.vncserver is None and args.vncports is None:
-            args.authonly = True
-        args.account = 'hires1'
+        ## Message user to specify an instrument account
+        print()
+        print("    ----------------------------------------------------------------")
+        print("    Due to updates to Keck's internal security systems, we no longer")
+        print("    support running start_keck_viewers without an instrument account")
+        print("    argument.")
+        print()
+        print("    If you wish to authenticate through the firewall without opening")
+        print("    VNC sessions, run start_keck_viewers with an instrument account")
+        print("    and the --authonly flag.")
+        print("    ----------------------------------------------------------------")
+        print()
+        sys.exit(0)
 
     return args
 

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -27,7 +27,7 @@ import soundplay
 
 
 ## Module vars
-__version__ = '2.0.13'
+__version__ = '2.1.0'
 supportEmail = 'remote-observing@keck.hawaii.edu'
 KRO_API = 'https://www3.keck.hawaii.edu/api/kroApi'
 SESSION_NAMES = ('control0', 'control1', 'control2',

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -28,9 +28,9 @@ import soundplay
 
 
 ## Module vars
-__version__ = '2.0.12'
+__version__ = '2.0.13'
 supportEmail = 'remote-observing@keck.hawaii.edu'
-KRO_API = 'https://www2.keck.hawaii.edu/inst/kroApi.php'
+KRO_API = 'https://www3.keck.hawaii.edu/api/kroApi'
 SESSION_NAMES = ('control0', 'control1', 'control2',
                  'analysis0', 'analysis1', 'analysis2',
                  'telanalys', 'telstatus')

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -822,7 +822,7 @@ class KeckVncLauncher(object):
         data = None
         try:
             tick = datetime.now()
-            data = requests.post(KRO_API, data=params, timeout=60)
+            data = requests.post(KRO_API, data=params, timeout=90)
             data = json.loads(data.text)
             for key in data.keys():
                 self.log.debug(f"  Got data for {key}: {data[key]}")

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -499,8 +499,7 @@ class KeckVncLauncher(object):
 
         ##---------------------------------------------------------------------
         ## Open web proxy if requested
-        if self.config.get('proxy_port', None) is not None and\
-           self.config.get('proxy_server', None) is not None:
+        if self.config.get('proxy_port', None) is not None:
             self.open_ssh_for_proxy()
 
 
@@ -1432,7 +1431,7 @@ class KeckVncLauncher(object):
             self.log.warning(f'Port 8080 is in use, not starting proxy connection')
             return
         self.log.info(f'Opening SSH for proxy to port 8080')
-        t = SSHProxy(self.config.get('proxy_server'),
+        t = SSHProxy(self.args.account,
                      self.kvnc_account, self.ssh_pkey,
                      local_port,
                      session_name='proxy',

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -27,7 +27,7 @@ import soundplay
 
 
 ## Module vars
-__version__ = '2.1.0'
+__version__ = '3.0.0'
 supportEmail = 'remote-observing@keck.hawaii.edu'
 KRO_API = 'https://www3.keck.hawaii.edu/api/kroApi'
 SESSION_NAMES = ('control0', 'control1', 'control2',

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -878,7 +878,7 @@ class KeckVncLauncher(object):
         self.log.debug(f'Using URL: {url}')
         data = None
         try:
-            data = urlopen(url, timeout=10).read().decode('utf8')
+            data = urlopen(url, timeout=60).read().decode('utf8')
             data = json.loads(data)
         except Exception as e:
             self.log.error(f'Could not get data from API.')

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -443,11 +443,6 @@ class KeckVncLauncher(object):
         self.default_sessions = []
         self.sessions_found = []
 
-        #default servers to try at Keck
-        servers = ['kcwi', 'mosfire']#, 'deimos', 'osiris']
-        domain = '.keck.hawaii.edu'
-        self.servers_to_try = [f"{server}{domain}" for server in servers]
-
         #local port start (can be overridden by config file)
         self.LOCAL_PORT_START = 5901
 
@@ -1112,14 +1107,6 @@ class KeckVncLauncher(object):
     ##-------------------------------------------------------------------------
     def get_vnc_server(self, account, instrument):
         '''Determine the VNC server to connect to given the instrument.
-        
-        Note that while this nominally cycles through all the servers in the
-        servers_to_try list, it is only reliably correct when connecting to a
-        solaris machine such as svncserver1 or svncserver2. The kvnc.cfg file
-        that those access at Keck is shared and up to date. The kvnc.cfg file
-        accessed by the linux instrument machines is deployed via KROOT and may
-        be out of date. As of this writing (July 2, 2020), ESI is incorrect on
-        those machines, but other instruments return a correct server.
         '''
 
         #cmd line option
@@ -1137,25 +1124,6 @@ class KeckVncLauncher(object):
             vncserver = self.api_data.get('vncserver')
             if not vncserver:
                 self.log.error(f'Could not determine VNC server from API')
-
-        #SSH Route
-        else:
-            self.log.info(f"Determining VNC server for '{self.args.account}' (via SSH)")
-            vncserver = None
-            for server in self.servers_to_try:
-                cmd = f'kvncinfo -server -I {instrument}'
-
-                try:
-                    data, rc = self.do_ssh_cmd(cmd, server, account)
-                except Exception as e:
-                    self.log.error('  Failed: ' + str(e))
-                    trace = traceback.format_exc()
-                    self.log.debug(trace)
-                    data = None
-
-                if data is not None and ' ' not in data and rc == 0:
-                    vncserver = data
-                    break
 
         if vncserver:
             self.log.info(f"Got VNC server: '{vncserver}'")

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -18,7 +18,7 @@ import sys
 from threading import Thread
 import time
 import traceback
-from urllib.request import urlopen
+import requests
 import warnings
 import yaml
 
@@ -872,14 +872,16 @@ class KeckVncLauncher(object):
         self.api_data = None
 
         #form API url and get data
-        url = f'{KRO_API}?key={self.api_key}'
-        if account is not False: url += f'&account={self.args.account}'
+        params = {'key': f'{self.api_key}'}
+        if account is not False: params['account'] = f'{self.args.account}'
         self.log.info(f'Calling KRO API to get account info')
-        self.log.debug(f'Using URL: {url}')
+        self.log.debug(f'Using URL: {KRO_API} with {params}')
         data = None
         try:
-            data = urlopen(url, timeout=60).read().decode('utf8')
-            data = json.loads(data)
+            data = requests.post(KRO_API, data=params, timeout=60)
+            data = json.loads(data.text)
+            for key in data.keys():
+                self.log.debug(f"  Got data for {key}")
         except Exception as e:
             self.log.error(f'Could not get data from API.')
             self.log.error(str(e))

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -606,7 +606,6 @@ class KeckVncLauncher(object):
         '''
         url = 'https://api.github.com/repos/KeckObservatory/RemoteObserving/releases'
         try:
-            import requests
             from packaging import version
             self.log.debug("Checking for latest version available on GitHub")
             r = requests.get(url, timeout=5)
@@ -1857,7 +1856,6 @@ class KeckVncLauncher(object):
         - The config file has a valid ssh_pkey path specified
         - The config file has a valid vncviewer executable path specified
         '''
-        import socket
         failcount = 0
 
         #API must be defined

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -133,7 +133,7 @@ def create_logger(args):
         Path('logs/').mkdir(parents=True, exist_ok=True)
     except PermissionError as error:
         print(str(error))
-        print(f"ERROR: Unable to create logger at {logFile}")
+        print(f"ERROR: Unable to create logger at logs/")
         print("Make sure you have write access to this directory.\n")
         log.info("EXITING APP\n")
         sys.exit(1)

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -5,7 +5,6 @@ import os
 import argparse
 import atexit
 from datetime import datetime, timedelta
-from getpass import getpass
 import json
 import logging
 import os
@@ -19,7 +18,6 @@ from threading import Thread
 import time
 import traceback
 import requests
-import warnings
 import yaml
 
 ## Import local modules

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -1247,14 +1247,15 @@ class KeckVncLauncher(object):
     ##-------------------------------------------------------------------------
     def open_ssh_for_proxy(self):
         local_port = int(self.config.get('proxy_port'))
+        proxy_server = self.api_data.get('vncserver')
         if self.is_proxy_open() is True:
             self.log.warning(f'SSH proxy already open on port 8080')
             return
         if is_local_port_in_use(local_port) is True:
             self.log.warning(f'Port 8080 is in use, not starting proxy connection')
             return
-        self.log.info(f'Opening SSH for proxy to port 8080')
-        t = SSHProxy(self.api_data.get('vncserver'),
+        self.log.info(f'Opening SSH to {proxy_server} for proxy to port 8080')
+        t = SSHProxy(proxy_server,
                      self.kvnc_account, self.ssh_pkey,
                      local_port,
                      session_name='proxy',

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -1725,8 +1725,7 @@ class KeckVncLauncher(object):
         logfile = Path(logfile_handlers.pop(0).baseFilename)
 
         source = str(logfile)
-        destination = self.vncserver if self.vncserver is not None\
-                                     else 'mosfire.keck.hawaii.edu'
+        destination = self.vncserver
         self.log.debug(f"Uploading to: {account}@{destination}:{logfile.name}")
         destination = account + '@' + destination + ':' + logfile.name
 
@@ -1932,22 +1931,6 @@ class KeckVncLauncher(object):
         return failcount
 
 
-    def test_localhost(self):
-        '''The localhost needs to be defined (e.g. 127.0.0.1)
-        '''
-        failcount = 0
-        self.log.info('Checking localhost')
-        if self.ping_cmd is None:
-            self.log.warning('No ping command defined.  Unable to test localhost.')
-            return 0
-        if self.ping('localhost') is False:
-            self.log.error(f"localhost appears not to be configured")
-            self.log.error(f"Your /etc/hosts file may need to be updated")
-            failcount += 1
-
-        return failcount
-
-
     def test_ssh_key_format(self):
         '''The SSH key must be RSA and must not use a passphrase
         '''
@@ -2009,18 +1992,22 @@ class KeckVncLauncher(object):
         '''Test:
         - Successfully connect to the listed servers at Keck and get a valid
         response from an SSH command.
+        - Now that the access list os limited to the destination instrument, we
+        only check connection to kcwi as that is the instrument used in the
+        `test_api` step.
         '''
         failcount = 0
-        servers_and_results = [('mosfire', 'vm-mosfire'),
-                               ('hires', 'vm-hires'),
-                               ('lris', 'vm-lris'),
-                               ('osiris', 'vm-osiris'),
-                               ('kpf', 'kpf'),
-                               ('deimos', 'deimos'),
-                               ('kcwi', 'vm-kcwi'),
-                               ('nirc2', 'vm-nirc2'),
-                               ('nires', 'vm-nires'),
-                               ('nirspec', 'vm-nirspec')]
+#         servers_and_results = [('mosfire', 'vm-mosfire'),
+#                                ('hires', 'vm-hires'),
+#                                ('lris', 'vm-lris'),
+#                                ('osiris', 'vm-osiris'),
+#                                ('kpf', 'kpf'),
+#                                ('deimos', 'deimos'),
+#                                ('kcwi', 'vm-kcwi'),
+#                                ('nirc2', 'vm-nirc2'),
+#                                ('nires', 'vm-nires'),
+#                                ('nirspec', 'vm-nirspec')]
+        servers_and_results = [('kcwi', 'vm-kcwi')]
         for server, result in servers_and_results:
             self.log.info(f'Testing SSH to {self.kvnc_account}@{server}.keck.hawaii.edu')
             tick = datetime.now()
@@ -2071,7 +2058,6 @@ class KeckVncLauncher(object):
         failcount += self.test_yaml_version()
         failcount += self.test_config_format()
         failcount += self.test_tigervnc()
-#         failcount += self.test_localhost()
         failcount += self.test_ssh_key_format()
         failcount += self.test_api()
         failcount += self.test_basic_connectivity()

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -874,8 +874,8 @@ class KeckVncLauncher(object):
         self.api_data = None
 
         #form API url and get data
-        params = {'key': f'{self.api_key}'}
-        if account is not False: params['account'] = f'{self.args.account}'
+        params = {'key': f'{self.api_key}',
+                  'account': f"{account}"}
         self.log.info(f'Calling KRO API to get account info')
         self.log.debug(f'Using URL: {KRO_API} with {params}')
         data = None

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -138,15 +138,20 @@ def create_logger(args):
         log.info("EXITING APP\n")
         sys.exit(1)
 
+    # Set up formats
+    logFormat_no_time = logging.Formatter(' %(levelname)8s: %(message)s')
+    logFormat_no_time.converter = time.gmtime
+    logFormat_with_time = logging.Formatter('%(asctime)s UT - %(levelname)s: %(message)s')
+    logFormat_with_time.converter = time.gmtime
+
     #stream/console handler
     logConsoleHandler = logging.StreamHandler()
     if args.verbose is True:
         logConsoleHandler.setLevel(logging.DEBUG)
+        logConsoleHandler.setFormatter(logFormat_with_time)
     else:
         logConsoleHandler.setLevel(logging.INFO)
-    logFormat = logging.Formatter(' %(levelname)8s: %(message)s')
-    logFormat.converter = time.gmtime
-    logConsoleHandler.setFormatter(logFormat)
+        logConsoleHandler.setFormatter(logFormat_no_time)
     log.addHandler(logConsoleHandler)
 
     #file handler (full debug logging)
@@ -154,9 +159,7 @@ def create_logger(args):
     logFile = Path(f'logs/keck-remote-log-utc-{ymd}.txt')
     logFileHandler = logging.FileHandler(logFile)
     logFileHandler.setLevel(logging.DEBUG)
-    logFormat = logging.Formatter('%(asctime)s UT - %(levelname)s: %(message)s')
-    logFormat.converter = time.gmtime
-    logFileHandler.setFormatter(logFormat)
+    logFileHandler.setFormatter(logFormat_with_time)
     log.addHandler(logFileHandler)
 
 


### PR DESCRIPTION
v3.0.0

- Remove firewall interaction, new API does this now.
- Use `requests` instead of `urllib`
- If a web proxy is configured, it will always use the instrument account host and ignore the requested proxy_server setting.
- Removes default behavior when no arguments are given. User must now supply an instrument account.
- No longer tries to determine the status of the firewall, always connects to API and assumes API handles firewall access.
- Removes several tests which are no longer applicable under the new scheme.
- Other minor bug fixes and improvements
