### PR TITLE
v3.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ The schedule is filled based on your remote observing request, but this is a man
 - Generate ssh public/private key pair **(do not set a passphrase)**
     ```
     cd ~/.ssh
-    ssh-keygen -t rsa -b 4096
+    ssh-keygen -t ed25519
     ```
-
-- Make sure that the resulting key is an RSA key.  The **private** key should have a first line which looks like `-----BEGIN RSA PRIVATE KEY-----` (it should not be an OPENSSH key).  If you do get an OPENSSH key (we've seen this on macOS and Ubuntu Linux), try generating the key with the `-m PEM` option: `ssh-keygen -t rsa -b 4096 -m PEM`
 
 - Upload your **public** key file at your [Observer Login Page](https://www2.keck.hawaii.edu/inst/PILogin/login.php). Click on "Manage Your Remote Observing SSH Key" and follow the instructions.
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,14 @@ A more extreme version would be to only keep one or two sessions open at a time 
 
 VNC does not carry sounds, so we have a separate system for playing instrument sounds such as "exposure complete" indicators on the remote machine.  This system has several moving parts, so troubleshooting can be challenging.  The vast majority of sound problems however are local to the users machine.  To play a test sound, type the `p` command.  This will play a local sound file (it will need to be downloaded on the first instance of this).  If you can't hear this test sound (the quality is poor and scratchy, but it sounds like a doorbell), then check your local machine's volume settings and speaker configuration.  You may also not have configured your local `aplay` instance properly.
 
+## No Sounds on macOS
+
+The Remote Observing software triggers sounds using one of several `soundplay` executables packaged with the software (in the `soundplayer/` subdirectory).  This has not been compiled on macOS for ARM (for "Apple Silicon") and relies on Apple's Rosetta software to convert an `x86_64` executable to something which can execute on modern Apple hardware.
+
+Normally the need to run the executable through Rosetta is detected automatically, but since we are calling the executable within a python program, it appears this is not happening.  Thus, if you are not getting sounds and everything else appears to be working, what may be happening is that the executable is not getting routed through Rosetta to be translated for Apple Silicon.
+
+The workaround for this is to manually call the executable once from the command line.  This attaches the proper metadata to the executable and it will work properly from within python thereafter.  This means one should navigate to the `soundplayer/` directory and call `./soundplay.darwin.x86_64` once.  Ignore the errors, and `control-c` out immediately.  After that, future connections to sounds via the Remote Observing software should run normally.
+
 # Upgrading the Software
 
 The software does a simple check to see if it is the latest released version.  You can see a log line with this information on startup, or you can get the saem result using the `v` command.

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ Note: The examples below assume sudo/root installation for all users and were or
     - **For macOS**: Install a VNC viewer application if needed.
         - [Tiger VNC](https://tigervnc.org) has the advantage of supporting automatic window positioning, but does not support scaling, and can not enter and exit view only mode interactively.
         - Real VNC's [VNC Viewer](https://www.realvnc.com/en/connect/download/viewer/) does not support automatic window positioning, but allows window scaling for use on small or high resolution monitors.  In addition, it supports changing modes both interactively and on the command line (e.g. scaling and the toggling of view only mode).  Note: this is the free software, you do not need VNC Viewer Plus.
-        - It is also possible to use the built in VNC viewer on macOS, but we have seen a few instances where the screen freezes and the client needs to be closed and reopened to get an up to date screen.
         - Both Tiger VNC and Real VNC have the viewers available for install via the macOS [Homebrew package manager](https://brew.sh). This provides the same software as is available from the download links above, but may be an easier install for users who already use homebrew.
             - To install Real VNC Viewer: `brew install vnc-viewer`
             - To install Tiger VNC Viewer: `brew install tigervnc-viewer`
+        - It is also possible to use the built in VNC viewer on macOS.  The example configuration file has an example setup for this in the "VNC Viewer Command" section for users who want to try it.  Be aware, however, that we have seen a few instances where the screen freezes and the client needs to be closed and reopened to get an up to date screen, so if you see that problem, please try another VNC Viewer client.
 
 **--> Important! <--** If you are using TigerVNC on either OS, in the `~/.vnc` directory, create a file named `default.tigervnc` with these two lines:
 ```

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Note: The examples below assume sudo/root installation for all users and were or
         - [Tiger VNC](https://tigervnc.org) has the advantage of supporting automatic window positioning, but does not support scaling, and can not enter and exit view only mode interactively.
         - Real VNC's [VNC Viewer](https://www.realvnc.com/en/connect/download/viewer/) does not support automatic window positioning, but allows window scaling for use on small or high resolution monitors.  In addition, it supports changing modes both interactively and on the command line (e.g. scaling and the toggling of view only mode).  Note: this is the free software, you do not need VNC Viewer Plus.
         - It is also possible to use the built in VNC viewer on macOS, but we have seen a few instances where the screen freezes and the client needs to be closed and reopened to get an up to date screen.
+        - Both Tiger VNC and Real VNC have the viewers available for install via the macOS [Homebrew package manager](https://brew.sh). This provides the same software as is available from the download links above, but may be an easier install for users who already use homebrew.
+            - To install Real VNC Viewer: `brew install vnc-viewer`
+            - To install Tiger VNC Viewer: `brew install tigervnc-viewer`
 
 **--> Important! <--** If you are using TigerVNC on either OS, in the `~/.vnc` directory, create a file named `default.tigervnc` with these two lines:
 ```

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -136,11 +136,12 @@ def create_logger(args):
         return
 
     #create log file and log dir if not exist
+    log_path = Path(__file__).parent / 'logs'
     try:
-        Path('logs/').mkdir(parents=True, exist_ok=True)
+        log_path.mkdir(parents=True, exist_ok=True)
     except PermissionError as error:
         print(str(error))
-        print(f"ERROR: Unable to create logger at logs/")
+        print(f"ERROR: Unable to create logger at {log_path}")
         print("Make sure you have write access to this directory.\n")
         log.info("EXITING APP\n")
         sys.exit(1)
@@ -168,7 +169,7 @@ def create_logger(args):
     except:
         # Works with older pyhon versions (>=3.9)
         ymd = datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S')
-    logFile = Path(f'logs/keck-remote-log-utc-{ymd}.txt')
+    logFile = log_path / f'keck-remote-log-utc-{ymd}.txt'
     logFileHandler = logging.FileHandler(logFile)
     logFileHandler.setLevel(logging.DEBUG)
     logFileHandler.setFormatter(logFormat_with_time)

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -433,9 +433,9 @@ class KeckVncLauncher(object):
         self.instrument = None
         self.vncserver = None
         self.ssh_key_valid = False
-        self.ssh_additional_kex = '+diffie-hellman-group1-sha1'
-        self.ssh_additional_hostkeyalgo = '+ssh-dss,ssh-rsa'
-        self.ssh_additional_keytypes = '+ssh-dss,ssh-rsa'
+        self.ssh_additional_kex = None
+        self.ssh_additional_hostkeyalgo = None
+        self.ssh_additional_keytypes = None
         self.exit = False
         self.geometry = list()
         self.tigervnc = None

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -91,8 +91,8 @@ def create_parser():
     ## add options
     parser.add_argument("-c", "--config", dest="config", type=str,
         help="Path to local configuration file.")
-#     parser.add_argument("--vncserver", type=str,
-#         help="Name of VNC server to connect to.  Takes precedence over all.")
+    parser.add_argument("--vncserver", type=str,
+        help="Name of VNC server to connect to.  Takes precedence over all.")
     parser.add_argument( '--vncports', nargs='+', type=str,
         help="Numerical list of VNC ports to connect to.  Takes precedence over all.")
 
@@ -252,10 +252,6 @@ class SSHTunnel(object):
         address_and_port = f"{username}@{server}:{remote_port}"
         self.log.info(f"Opening SSH tunnel for {address_and_port} "
                  f"on local port {local_port}.")
-
-        if re.match(r'svncserver\d.keck.hawaii.edu', server) is not None:
-            self.log.debug('Extending timeout for svncserver connections')
-            timeout = 60
 
         # We now know everything we need to know in order to establish the
         # tunnel. Build the command line options and start the child process.
@@ -1085,9 +1081,9 @@ class KeckVncLauncher(object):
                 self.log.error(f'Could not determine VNC server from API')
 
         #cmd line option
-#         if self.args.vncserver is not None:
-#             self.log.info("Using VNC server defined on command line")
-#             vncserver = self.args.vncserver
+        if self.args.vncserver is not None:
+            self.log.info("Using VNC server defined on command line")
+            vncserver = self.args.vncserver
 
         if vncserver:
             self.log.info(f"Got VNC server: '{vncserver}'")

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -25,7 +25,7 @@ import soundplay
 
 
 ## Module vars
-__version__ = '3.0.4'
+__version__ = '3.0.5'
 supportEmail = 'remote-observing@keck.hawaii.edu'
 KRO_API = 'https://www3.keck.hawaii.edu/api/kroApi/'
 SESSION_NAMES = ('control0', 'control1', 'control2',

--- a/keck_vnc_launcher.py
+++ b/keck_vnc_launcher.py
@@ -1963,21 +1963,6 @@ class KeckVncLauncher(object):
         with open(self.ssh_pkey, 'r') as f:
             contents = f.read()
 
-        # Check if this is an RSA key
-#         foundrsa = re.search('BEGIN RSA PRIVATE KEY', contents)
-#         if not foundrsa:
-#             self.log.error(f"Your private key does not appear to be an RSA key")
-#             failcount += 1
-
-        # Check if this is an OPENSSH key
-        foundopenssh = re.search('BEGIN OPENSSH PRIVATE KEY', contents)
-        if foundopenssh:
-            self.log.warning(f"Your SSH key may or may not be formatted correctly.")
-            self.log.warning(f"If no other tests fail and you can connect to the Keck VNCs,")
-            self.log.warning(f"then you can ignore this message.  If you can not connect,")
-            self.log.warning(f"then try regenerating and uploading your SSH key and make")
-            self.log.warning(f"sure you use the `-m PEM` option when generating the key.")
-
         # Check that there is no passphrase
         foundencrypt = re.search(r'Proc-Type: \d,ENCRYPTED', contents)
         if foundencrypt:

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -1,26 +1,27 @@
 #!/bin/bash -i
 
 # If we're using conda python
-if [ "$CONDA_PREFIX" != "" ]; then
-    # NOTE: The KRO environment is created with:
-    #       conda env create -f environment.yaml
+CONDAEXE=$(which conda)
+echo "CONDAEXE:   $CONDAEXE"
+
+if [ "$CONDAEXE" != "" ]; then
     CONDA_BASE=$(conda info --base)
-    echo "Found CONDA_BASE=$CONDA_BASE"
+    echo "CONDA_BASE: $CONDA_BASE"
     source $CONDA_BASE/etc/profile.d/conda.sh
 
-    #get script dir (so we know full path to keck_vnc_launcher.py)
-    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-    echo "Found DIR=$DIR"
+    KROLINE=$(conda info --envs | grep KRO)
+    echo "KROLINE:    $KROLINE"
 
-    # Launch the script
-    if [ -e $CONDA_BASE/envs/KRO/bin/python3 ]; then
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    echo "DIR:        $DIR"
+
+    if [ "$KROLINE" != "" ]; then
         echo "Launching using conda KRO environment"
         conda activate KRO
-        $CONDA_BASE/envs/KRO/bin/python3 $DIR/keck_vnc_launcher.py -c $DIR/local_config.yaml $@
     else
         echo "Launching using conda current environment"
-        $CONDA_BASE/bin/python3 $DIR/keck_vnc_launcher.py -c $DIR/local_config.yaml $@
     fi
+    python3 $DIR/keck_vnc_launcher.py -c $DIR/local_config.yaml $@
 else
     echo "We are unable to determine the correct python version to run the"
     echo "Remote Observing software.  We will now try a generic python3 call,"

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -1,25 +1,23 @@
-#!/bin/bash
+#!/bin/bash -i
 
 # If we're using conda python
 if [ "$CONDA_PREFIX" != "" ]; then
-    # activate conda environment
     # NOTE: The KRO environment is created with:
     #       conda env create -f environment.yaml
-    source $CONDA_PREFIX/etc/profile.d/conda.sh
-    conda deactivate
-    conda activate KRO
+    CONDA_BASE=$(conda info --base)
+    source $CONDA_BASE/etc/profile.d/conda.sh
 
-    #change to script dir (so we don't need full path to keck_vnc_launcher.py)
+    #get script dir (so we know full path to keck_vnc_launcher.py)
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-    cd $DIR
 
     # Launch the script
-    if [ -e $CONDA_PREFIX/envs/KRO/bin/python3 ]; then
-        # Launch using conda KRO environment
-        $CONDA_PREFIX/envs/KRO/bin/python3 keck_vnc_launcher.py $@
+    if [ -e $CONDA_BASE/envs/KRO/bin/python3 ]; then
+        echo "Launching using conda KRO environment"
+        conda activate KRO
+        $CONDA_BASE/envs/KRO/bin/python3 $DIR/keck_vnc_launcher.py $@
     else
-        # Try launching via conda base environment
-        $CONDA_PREFIX/bin/python3 keck_vnc_launcher.py $@
+        echo "Launching via conda current environment"
+        $CONDA_BASE/bin/python3 $DIR/keck_vnc_launcher.py $@
     fi
 else
     echo "We are unable to determine the correct python version to run the"
@@ -28,7 +26,7 @@ else
     echo "correct python version for your system and use the same arguments you"
     echo "would use with the start_keck_viewers script.  For example:"
     echo "  /path/to/python3 keck_vnc_launcher.py numbered_account"
-    echo "Of coure, you should use the proper path to your python executable"
+    echo "Of course, you should use the proper path to your python executable"
     echo "and the correct numbered account."
 
     # just try whatever is in the path and hope it works

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -1,14 +1,14 @@
 #!/bin/bash -i
 
-#get script dir (so we know full path to keck_vnc_launcher.py)
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 # If we're using conda python
 if [ "$CONDA_PREFIX" != "" ]; then
     # NOTE: The KRO environment is created with:
     #       conda env create -f environment.yaml
     CONDA_BASE=$(conda info --base)
     source $CONDA_BASE/etc/profile.d/conda.sh
+
+    #get script dir (so we know full path to keck_vnc_launcher.py)
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
     # Launch the script
     if [ -e $CONDA_BASE/envs/KRO/bin/python3 ]; then
@@ -30,5 +30,5 @@ else
     echo "and the correct numbered account."
 
     # just try whatever is in the path and hope it works
-    python3 $DIR/keck_vnc_launcher.py $@
+    python3 keck_vnc_launcher.py $@
 fi

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -1,14 +1,14 @@
 #!/bin/bash -i
 
+#get script dir (so we know full path to keck_vnc_launcher.py)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 # If we're using conda python
 if [ "$CONDA_PREFIX" != "" ]; then
     # NOTE: The KRO environment is created with:
     #       conda env create -f environment.yaml
     CONDA_BASE=$(conda info --base)
     source $CONDA_BASE/etc/profile.d/conda.sh
-
-    #get script dir (so we know full path to keck_vnc_launcher.py)
-    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
     # Launch the script
     if [ -e $CONDA_BASE/envs/KRO/bin/python3 ]; then
@@ -30,5 +30,5 @@ else
     echo "and the correct numbered account."
 
     # just try whatever is in the path and hope it works
-    python3 keck_vnc_launcher.py $@
+    python3 $DIR/keck_vnc_launcher.py $@
 fi

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -16,10 +16,10 @@ if [ "$CONDA_PREFIX" != "" ]; then
     if [ -e $CONDA_BASE/envs/KRO/bin/python3 ]; then
         echo "Launching using conda KRO environment"
         conda activate KRO
-        $CONDA_BASE/envs/KRO/bin/python3 $DIR/keck_vnc_launcher.py $@
+        $CONDA_BASE/envs/KRO/bin/python3 $DIR/keck_vnc_launcher.py -c $DIR/local_config.yaml $@
     else
         echo "Launching using conda current environment"
-        $CONDA_BASE/bin/python3 $DIR/keck_vnc_launcher.py $@
+        $CONDA_BASE/bin/python3 $DIR/keck_vnc_launcher.py -c $DIR/local_config.yaml $@
     fi
 else
     echo "We are unable to determine the correct python version to run the"

--- a/start_keck_viewers
+++ b/start_keck_viewers
@@ -5,10 +5,12 @@ if [ "$CONDA_PREFIX" != "" ]; then
     # NOTE: The KRO environment is created with:
     #       conda env create -f environment.yaml
     CONDA_BASE=$(conda info --base)
+    echo "Found CONDA_BASE=$CONDA_BASE"
     source $CONDA_BASE/etc/profile.d/conda.sh
 
     #get script dir (so we know full path to keck_vnc_launcher.py)
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    echo "Found DIR=$DIR"
 
     # Launch the script
     if [ -e $CONDA_BASE/envs/KRO/bin/python3 ]; then
@@ -16,7 +18,7 @@ if [ "$CONDA_PREFIX" != "" ]; then
         conda activate KRO
         $CONDA_BASE/envs/KRO/bin/python3 $DIR/keck_vnc_launcher.py $@
     else
-        echo "Launching via conda current environment"
+        echo "Launching using conda current environment"
         $CONDA_BASE/bin/python3 $DIR/keck_vnc_launcher.py $@
     fi
 else


### PR DESCRIPTION
Changes:
- Refactors shell script to avoid conda error messages
- Adds README info for `brew` users on macOS
- Add `ssh_path` option to local config file to allow users to explicitly set which install of ssh to use.
- Fix logs/ subdirectory to be created under the install directory of this software rather than under cwd when run.
- Instruct users to use more modern SSH key (`ed25519` instead of `rsa`)
- Remove old SSH parameters which are incompatible with some modern SSH versions
- Add troubleshooting entry for sounds on macOS